### PR TITLE
Adds GEO Shortcodes / Displays Non-WPE Environment Notice / Updates Documentation

### DIFF
--- a/geoip.php
+++ b/geoip.php
@@ -196,7 +196,7 @@ class GeoIp {
 	 */
 	public function action_admin_init_check_plugin_dependencies() {
 		// Check to see if the environment variables are present
-		if( ! empty( ( getenv( 'HTTP_GEOIP_COUNTRY_CODE' ) ) ) ) {
+		if( empty( ( getenv( 'HTTP_GEOIP_COUNTRY_CODE' ) ) ) ) {
 			$this->admin_notices[] = __( 'Please note - this plugin will only function on your <a href="http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN . '">WP Engine account</a>. This will not function outside of the WP Engine environment. Plugin <b>deactivated.</b>', self::TEXT_DOMAIN );
 		}
 

--- a/geoip.php
+++ b/geoip.php
@@ -196,7 +196,7 @@ class GeoIp {
 	 */
 	public function action_admin_init_check_plugin_dependencies() {
 		// Check to see if the environment variables are present
-		if( empty( ( getenv( 'HTTP_GEOIP_COUNTRY_CODE' ) ) ) ) {
+		if( empty( getenv( 'HTTP_GEOIP_COUNTRY_CODE' ) ) ) ) {
 			$this->admin_notices[] = __( 'Please note - this plugin will only function on your <a href="http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN . '">WP Engine account</a>. This will not function outside of the WP Engine environment. Plugin <b>deactivated.</b>', self::TEXT_DOMAIN );
 		}
 

--- a/geoip.php
+++ b/geoip.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WP Engine GeoIP
-Version: 1.0.0
+Version: 0.5.0
 Description: Create a personalized user experienced based on location.
 Author: WP Engine
 Author URI: http://wpengine.com

--- a/geoip.php
+++ b/geoip.php
@@ -160,7 +160,7 @@ class GeoIp {
 		if( isset( $this->geos[ 'country' ] ) ) {
 			return $this->country();
 		}
-		return '[' . self::SHORTCODE_COUNTRY . ']';
+		return '[a' . self::SHORTCODE_COUNTRY . ']';
 	}
 
 	/**

--- a/geoip.php
+++ b/geoip.php
@@ -1,10 +1,16 @@
 <?php
 /*
- * Plugin Name: WP Engine Geo
- * Version: 0.4
- * Author: WP Engine Labs
- *
- * Examples use of how to add geoip information to post content:
+Plugin Name: WP Engine GeoIP
+Version: 1.0.0
+Description: Create a personalized user experienced based on location.
+Author: WP Engine
+Author URI: http://wpengine.com
+Plugin URI: https://wordpress.org/plugins/wpe-geo-ip/
+Text Domain: wpe-geo-ip
+Domain Path: /languages
+*/
+
+/* Examples use of how to add geoip information to post content:
 
 function geoip_append_content( $content ) {
 	$geo = WPEngine\GeoIp::instance();
@@ -28,23 +34,55 @@ class GeoIp {
 	// The geographical data loaded from the environment
 	public $geos;
 
+	// Dependency management
+	private $plugin_dependencies   = array();
+	private $depenencies_present   = false;
+	private $admin_notices         = array();
+
+	/* Shortcode */
+	const SHORTCODE_COUNTRY = 'geoip-country';
+	const SHORTCODE_REGION  = 'geoip-region';
+	const SHORTCODE_CITY    = 'geoip-city';
+
+	const TEXT_DOMAIN       = 'wpe-geo-ip';
+
+	/**
+	 * [init description]
+	 * @return [type] [description]
+	 */
 	public static function init() {
+
+		// Check for dependencies
+		add_action( 'admin_init', array( self::instance(), 'action_admin_init_check_plugin_dependencies' ), 9999 ); // check late
+
+		// Initialize
 		add_action( 'init', array( self::instance(), 'setup' ) );
+		add_action( 'init', array( self::instance(), 'action_init_register_shortcodes' ) );
 	}
 
+	/**
+	 * [instance description]
+	 * @return [type] [description]
+	 */
 	public static function instance() {
 		// create a new object if it doesn't exist.
 		is_null( self::$instance ) && self::$instance = new self;
 		return self::$instance;
 	}
 
+	/**
+	 * [setup description]
+	 * @return [type] [description]
+	 */
 	public function setup() {
 		$this->geos = $this->get_actuals();
 	}
 
 	/**
- 	 * Here we extract the data from headers set by nginx -- lets only send them if they are part of the cache key
- 	 **/
+	 * Here we extract the data from headers set by nginx -- lets only send them if they are part of the cache key
+	 *
+	 * @return [type] [description]
+	 */
 	public function get_actuals() {
 		return array(
 			'countrycode'  => getenv( 'HTTP_GEOIP_COUNTRY_CODE' ),
@@ -62,29 +100,135 @@ class GeoIp {
 	/**
 	 * Examples of easy to use utility functions that we should have for each geo that is part of the cache key
 	 *
-	 * @return mixed
+	 * @return mixed Description
 	 */
 	public function country() {
-		return $this->geos['countrycode'];
+		return $this->geos[ 'countrycode' ];
 	}
 
 	/**
-	 * @return mixed
+	 * Region
+	 *
+	 * @return mixed Description
 	 */
 	public function region() {
-		return $this->geos['region'];
+		return $this->geos[ 'region' ];
 	}
 
 	/**
-	 * @return mixed
+	 *
+	 *
+	 * @return mixed Description
 	 */
 	public function city() {
-		return $this->geos['city'];
+		return $this->geos[ 'city' ];
+	}
+
+	/**
+	 * Register the shortcode(s)
+	 *
+	 * @since  1.0.0
+	 * @uses add_shortcode()
+	 * @return null
+	 */
+	public function action_init_register_shortcodes() {
+
+		// Country Shortcode
+		if ( ! shortcode_exists( self::SHORTCODE_COUNTRY ) ) {
+			add_shortcode( self::SHORTCODE_COUNTRY, array( $this, 'do_shortcode_country' ) );
+		}
+
+		// Region Shortcode
+		if ( ! shortcode_exists( self::SHORTCODE_REGION ) ) {
+			add_shortcode( self::SHORTCODE_REGION, array( $this, 'do_shortcode_region' ) );
+		}
+
+		// City Shortcode
+		if ( ! shortcode_exists( self::SHORTCODE_CITY ) ) {
+			add_shortcode( self::SHORTCODE_CITY, array( $this, 'do_shortcode_city' ) );
+		}
+
+	}
+
+	/**
+	 * Output the current country
+	 *
+	 * @since  1.0.0
+	 * @return string $html
+	 */
+	function do_shortcode_country( $atts ) {
+		if( isset( $this->geos[ 'country' ] ) ) {
+			return $this->country();
+		}
+		return '[' . self::SHORTCODE_COUNTRY . ']';
+	}
+
+	/**
+	 * Output the current region
+	 *
+	 * @since  1.0.0
+	 * @return string $html
+	 */
+	function do_shortcode_region( $atts ) {
+		if( isset( $this->geos[ 'region' ] ) ) {
+			return $this->region();
+		}
+		return '[' . self::SHORTCODE_REGION . ']';
+	}
+
+	/**
+	 * Output the current city
+	 *
+	 * @since  1.0.0
+	 * @return string $html
+	 */
+	function do_shortcode_city( $atts ) {
+		if( isset( $this->geos[ 'city' ] ) ) {
+			return $this->city();
+		}
+		return '[' . self::SHORTCODE_CITY . ']';
+	}
+
+
+	/**
+	 * [action_admin_init_check_plugin_dependencies description]
+	 * @return [type] [description]
+	 */
+	public function action_admin_init_check_plugin_dependencies() {
+		// Check to see if the environment variables are present
+		if( ! empty( ( getenv( 'HTTP_GEOIP_COUNTRY_CODE' ) ) ) ) {
+			$this->admin_notices[] = __( 'Please note - this plugin will only function on your <a href="http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN . '">WP Engine account</a>. This will not function outside of the WP Engine environment. Plugin <b>deactivated.</b>', self::TEXT_DOMAIN );
+		}
+
+		// If required plugins are not present, throw an error notice and bail
+		if( ! $this->depenencies_present ) {
+			add_action( 'admin_notices', array( self::instance(), 'action_admin_notices' ) );
+			return;
+		}
+	}
+
+	/**
+	 * [action_admin_notices description]
+	 * @return [type] [description]
+	 */
+	public function action_admin_notices() {
+		if( 0 < count( $this->admin_notices ) ) {
+			// Hide the activation message
+			echo '<style>.wrap .updated{display:none;}</style>';
+
+			// Display the errors
+			echo '<div class="error">';
+			foreach( $this->admin_notices as $notice ) {
+				echo "<p>$notice</p>";
+			}
+			echo '</div>';
+
+			// Disable this plugin
+			deactivate_plugins( plugin_basename( __FILE__ ) );
+		}
 	}
 
 }
 
-/**
- * Register to do the stuff
- */
+// Register to do the stuff
 GeoIp::init();

--- a/geoip.php
+++ b/geoip.php
@@ -160,7 +160,7 @@ class GeoIp {
 		if( isset( $this->geos[ 'country' ] ) ) {
 			return $this->country();
 		}
-		return '[a' . self::SHORTCODE_COUNTRY . ']';
+		return '[' . self::SHORTCODE_COUNTRY . ']';
 	}
 
 	/**

--- a/geoip.php
+++ b/geoip.php
@@ -196,8 +196,8 @@ class GeoIp {
 	 */
 	public function action_admin_init_check_plugin_dependencies() {
 		// Check to see if the environment variables are present
-		$stuff = getenv( 'HTTP_GEOIP_COUNTRY_CODE' );
-		if( empty( $stuff ) ) {
+		$is_wpe = getenv( 'HTTP_GEOIP_COUNTRY_CODE' );
+		if( ! isset( $is_wpe ) || empty( $is_wpe ) ) {
 			$this->admin_notices[] = __( 'Please note - this plugin will only function on your <a href="http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN . '">WP Engine account</a>. This will not function outside of the WP Engine environment. Plugin <b>deactivated.</b>', self::TEXT_DOMAIN );
 		}
 
@@ -206,6 +206,7 @@ class GeoIp {
 			add_action( 'admin_notices', array( self::instance(), 'action_admin_notices' ) );
 			return;
 		}
+		unset( $is_wpe );
 	}
 
 	/**

--- a/geoip.php
+++ b/geoip.php
@@ -196,7 +196,8 @@ class GeoIp {
 	 */
 	public function action_admin_init_check_plugin_dependencies() {
 		// Check to see if the environment variables are present
-		if( empty( getenv( 'HTTP_GEOIP_COUNTRY_CODE' ) ) ) ) {
+		$stuff = getenv( 'HTTP_GEOIP_COUNTRY_CODE' );
+		if( empty( $stuff ) ) {
 			$this->admin_notices[] = __( 'Please note - this plugin will only function on your <a href="http://wpengine.com/plans/?utm_source=' . self::TEXT_DOMAIN . '">WP Engine account</a>. This will not function outside of the WP Engine environment. Plugin <b>deactivated.</b>', self::TEXT_DOMAIN );
 		}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,14 +1,39 @@
-=== Plugin Name ===
-Contributors: markkelnar
+=== WP Engine GeoIP ===
+Contributors: wpengine, markkelnar, stevenkword
+Tags: geo, geolocation, geoip,localization, wordpressengine, wpe, wpengine, wpenginegeoip
 Requires at least: 3.0.1
-Tested up to: 4.0.1
-Stable tag: 0.4
+Tested up to: 4.1
+Stable tag: 1.0.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Here is a short description of the plugin.  This should be no more than 150 characters.  No markup here.
+Create a personalized user experienced based on location.
 
 == Description ==
+
+WP Engine GeoIP integrates with the variables on your WP Engine site to display content catered to the visitor’s IP address. With the ability to access variables from as broad as country to as specific as latitude and longitude, your website can now display geographically relevant content.
+
+= Geo-Marketing =
+
+* Create marketing campaigns targeted only at certain locations.
+
+= Localization =
+
+* Redirect incoming traffic to content in the local language or currency
+* Businesses with local branches can direct customers to a relevant physical location or local microsite
+
+= Ecommerce =
+
+* Filter out merchandise or services that are not available in a certain locale
+* Display country-specific shipping, tax, or sales information
+
+= Legal Requirements =
+
+* Filter required legal notices from countries for whom those notices may not be relevant.
+
+= ** Please Note =
+
+This plugin will only function on your WP Engine account. This will not function outside of the WP Engine environment.
 
 == Installation ==
 
@@ -16,6 +41,14 @@ Here is a short description of the plugin.  This should be no more than 150 char
 2. Activate the plugin through the 'Plugins' menu in WordPress
 
 == Frequently Asked Questions ==
+
+This is a required Section
+
+== Screenshots ==
+
+This is a required Section
+
+== Upgrade Notice ==
 
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: wpengine, markkelnar, stevenkword
 Tags: geo, geolocation, geoip,localization, wordpressengine, wpe, wpengine, wpenginegeoip
 Requires at least: 3.0.1
 Tested up to: 4.1
-Stable tag: 1.0.0
+Stable tag: 0.5.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -51,6 +51,11 @@ This is a required Section
 == Upgrade Notice ==
 
 == Changelog ==
+
+= 0.5 =
+- Adds shortcodes for city, region, and country.
+- Displays admin notice when GEOIP environment variables are absent.
+- Formatting updates to readme and file headers.
 
 = 0.4 =
 - Code cleanup for WordPress coding standards and white space.


### PR DESCRIPTION
Adds shortcodes for use in the text editor: [geoip-city], [geoip-country], [geoip-region]

Displays notice upon plugin activation if the WPE environment variables for GEOIP is not present and deactivates the plugin.

Updates PHPDoc and file headers